### PR TITLE
Fix 'getSearchHistory' query

### DIFF
--- a/app/src/main/java/com/example/moviesearch/MainActivity.kt
+++ b/app/src/main/java/com/example/moviesearch/MainActivity.kt
@@ -118,8 +118,16 @@ class MainActivity : AppCompatActivity() {
         activityResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if(result.resultCode == RESULT_OK) { // 최근 검색 이력을 클릭했을 때만 실행
                 movieRecyclerViewAdapter.clearItem()
-                val selectedSearchName = result.data?.getStringExtra("SEARCH_NAME")
-                selectedSearchName?.let { binding.editTextSearch.setText(it) }
+                val selectedSearchName = result.data?.getStringExtra("SEARCH_NAME")!!
+                binding.editTextSearch.setText(selectedSearchName)
+
+                // 검색 이력 저장
+                val searchHistoryDto = SearchHistory(
+                    time = Date(System.currentTimeMillis()),
+                    searchName = selectedSearchName
+                )
+                localDatabaseViewModel.insertHistory(searchHistoryDto) // INSERT
+
                 // 검색 결과 호출
                 naverOpenApiManager.getMovieInfo(partTitle = selectedSearchName,
                     success = { list, nextPage ->

--- a/app/src/main/java/com/example/moviesearch/SearchHistoryActivity.kt
+++ b/app/src/main/java/com/example/moviesearch/SearchHistoryActivity.kt
@@ -35,6 +35,7 @@ class SearchHistoryActivity : AppCompatActivity() {
 
         // 검색 이력 Observer
         localDatabaseViewModel.searchNameLiveData.observe(this, {
+            it.forEach { Log.d("debug", it) }
             if(it.isEmpty()) binding.noSearchHistoryTextView.visibility = View.VISIBLE
             else movieTitleRecyclerViewAdapter.addItem(it) // Add item
         })

--- a/app/src/main/java/com/example/moviesearch/room/dao/SearchHistoryDao.kt
+++ b/app/src/main/java/com/example/moviesearch/room/dao/SearchHistoryDao.kt
@@ -7,7 +7,7 @@ import com.example.moviesearch.room.entities.SearchHistory
 
 @Dao
 interface SearchHistoryDao {
-    @Query("SELECT searchName FROM SearchHistory GROUP BY searchName ORDER BY time DESC LIMIT :limit")
+    @Query("SELECT searchName FROM SearchHistory WHERE time IN (SELECT MAX(time) FROM SearchHistory GROUP BY searchName) ORDER BY time DESC LIMIT :limit")
     fun getSearchHistory(limit: Int): List<String>
 
     @Insert

--- a/app/src/main/res/layout/activity_search_history.xml
+++ b/app/src/main/res/layout/activity_search_history.xml
@@ -17,17 +17,6 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"/>
 
-    <TextView
-        android:id="@+id/no_search_history_text_view"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:text="@string/no_search_history"
-        android:textSize="18sp"
-        android:gravity="center"
-        app:layout_constraintTop_toBottomOf="@id/activity_title"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:visibility="gone"/>
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/movie_title_recycler_view"
         android:layout_width="match_parent"
@@ -38,4 +27,14 @@
         app:layout_constraintTop_toBottomOf="@id/activity_title"
         app:layout_constraintBottom_toBottomOf="parent"/>
 
+    <TextView
+        android:id="@+id/no_search_history_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:text="@string/no_search_history"
+        android:textSize="18sp"
+        android:gravity="center"
+        app:layout_constraintTop_toBottomOf="@id/activity_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:visibility="gone"/>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
[쿼리 변경]
SELECT searchName FROM SearchHistory GROUP BY searchName ORDER BY time DESC LIMIT :limit
동일한 searchName이 있고, 해당 searchName이 상위 10개 내의 최신 검색 이력이라도 출력되지 않는 문제가 있음
->

SELECT searchName FROM SearchHistory 
  WHERE time IN (SELECT MAX(time) FROM SearchHistory GROUP BY searchName) 
  ORDER BY time DESC 
  LIMIT :limit